### PR TITLE
refactor theme to corporate blue palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,46 +9,46 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     html, body { height: 100%; }
-    :root { --accent: #facc15; }
-    body { background:#000; color:#fff; }
-    .glass { backdrop-filter: blur(8px); background: rgba(0,0,0,0.6); }
-    .btn { display:inline-flex; align-items:center; justify-content:center; padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; font-weight:500; transition: box-shadow .2s, border-color .2s, background .2s, color .2s; background:#000; color:var(--accent); cursor:pointer; }
-    .btn:hover { box-shadow:0 1px 2px rgba(250,204,21,.4); background:var(--accent); color:#000; }
-    .btn-primary { background:var(--accent); color:#000; border-color:var(--accent); }
-    .btn-primary:hover { background:#eab308; }
+    :root { --accent: #2563eb; }
+    body { background:#f9fafb; color:#111827; }
+    .glass { backdrop-filter: blur(8px); background: rgba(255,255,255,0.6); }
+    .btn { display:inline-flex; align-items:center; justify-content:center; padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; font-weight:500; transition: box-shadow .2s, border-color .2s, background .2s, color .2s; background:#fff; color:var(--accent); cursor:pointer; }
+    .btn:hover { box-shadow:0 1px 2px rgba(37,99,235,.4); background:var(--accent); color:#fff; }
+    .btn-primary { background:var(--accent); color:#fff; border-color:var(--accent); }
+    .btn-primary:hover { background:#1e40af; }
     .btn-danger { background:#dc2626; color:#fff; border-color:#b91c1c; }
     .btn-danger:hover { background:#b91c1c; }
-    .card { border:1px solid var(--accent); border-radius:1rem; padding:1rem; background:#111; box-shadow:0 1px 2px rgba(0,0,0,.5); }
+    .card { border:1px solid var(--accent); border-radius:1rem; padding:1rem; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,.1); }
     .grid-2 { display:grid; grid-template-columns:1fr; gap:1rem; }
     .grid-3 { display:grid; grid-template-columns:1fr; gap:1rem; }
     @media (min-width:768px) { .grid-2{grid-template-columns:repeat(2,minmax(0,1fr))} .grid-3{grid-template-columns:repeat(3,minmax(0,1fr))} }
-    .pill { border:1px solid var(--accent); border-radius:9999px; padding:.125rem .5rem; font-size:.75rem; font-weight:600; color:var(--accent); background:#000; }
-    .tab { padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; background:#000; color:var(--accent); cursor:pointer; transition: background .2s, color .2s; }
-    .tab:hover { background:var(--accent); color:#000; }
-    .tab-active { background:var(--accent); color:#000; border-color:var(--accent); }
-    .input { width:100%; border:1px solid var(--accent); border-radius:.75rem; padding:.5rem .75rem; outline:none; background:#000; color:#fff; }
-    .input:focus { box-shadow:0 0 0 2px rgba(250,204,21,0.3); border-color:var(--accent); }
+    .pill { border:1px solid var(--accent); border-radius:9999px; padding:.125rem .5rem; font-size:.75rem; font-weight:600; color:var(--accent); background:#fff; }
+    .tab { padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; background:#fff; color:var(--accent); cursor:pointer; transition: background .2s, color .2s; }
+    .tab:hover { background:var(--accent); color:#fff; }
+    .tab-active { background:var(--accent); color:#fff; border-color:var(--accent); }
+    .input { width:100%; border:1px solid var(--accent); border-radius:.75rem; padding:.5rem .75rem; outline:none; background:#fff; color:#111827; }
+    .input:focus { box-shadow:0 0 0 2px rgba(37,99,235,0.3); border-color:var(--accent); }
     .label { font-size:.75rem; font-weight:700; color:var(--accent); }
-    .table { width:100%; font-size:.875rem; border-collapse:collapse; color:#fff; }
+    .table { width:100%; font-size:.875rem; border-collapse:collapse; color:#111827; }
     .table th { text-align:left; color:var(--accent); font-weight:600; border-bottom:1px solid var(--accent); padding:.5rem .25rem; }
-    .table td { border-bottom:1px solid #333; padding:.5rem .25rem; }
-    .kbd { display:inline-block; border:1px solid var(--accent); border-radius:.375rem; padding:0 .25rem; font-size:.75rem; background:#111; color:var(--accent); }
+    .table td { border-bottom:1px solid #ddd; padding:.5rem .25rem; }
+    .kbd { display:inline-block; border:1px solid var(--accent); border-radius:.375rem; padding:0 .25rem; font-size:.75rem; background:#f3f4f6; color:#111827; }
     .divider { height:1px; background:var(--accent); margin:1rem 0; }
     .hidden { display:none !important; }
   </style>
 </head>
-<body class="min-h-full bg-black text-white">
+  <body class="min-h-full bg-gray-50 text-gray-900">
   <!-- Header -->
-  <header class="sticky top-0 z-40 bg-black/90 backdrop-blur border-b border-yellow-500">
+  <header class="sticky top-0 z-40 bg-white/90 backdrop-blur border-b border-blue-600">
     <div class="max-w-7xl mx-auto px-4 py-3 flex flex-col sm:flex-row items-start sm:items-center gap-3">
       <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-lg bg-yellow-500 text-black grid place-items-center font-bold">SF</div>
+        <div class="w-8 h-8 rounded-lg bg-blue-600 text-white grid place-items-center font-bold">SF</div>
         <div class="font-semibold">ShowFlow</div>
       </div>
       <nav class="w-full sm:w-auto flex flex-wrap items-center gap-2 mt-2 sm:mt-0 sm:ml-auto">
         <button id="navAdmin" class="tab">Admin</button>
         <button id="navParticipant" class="tab">Participant</button>
-        <span class="text-yellow-500">|</span>
+        <span class="text-blue-600">|</span>
         <button id="navExport" class="tab" title="Export all data">Export</button>
         <label class="tab cursor-pointer" title="Import a previously exported JSON">
           <input id="importInput" type="file" accept="application/json" class="hidden" />
@@ -60,7 +60,7 @@
 
   <main class="max-w-7xl mx-auto p-4 space-y-6">
     <!-- System banners -->
-    <div id="banner" class="hidden p-3 rounded-xl border border-yellow-500 bg-black text-yellow-500"></div>
+      <div id="banner" class="hidden p-3 rounded-xl border border-blue-600 bg-white text-blue-600"></div>
 
     <!-- Admin Auth -->
     <section id="viewAdminAuth" class="card">


### PR DESCRIPTION
## Summary
- replace black/yellow color scheme with light blue corporate palette
- lighten buttons, cards, inputs, and header to match new theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7345b5dd48330b70f9e29871b7192