### PR TITLE
fix: show tools dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <div class="w-8 h-8 rounded-lg bg-blue-600 text-white grid place-items-center font-bold">SF</div>
         <div class="font-semibold">ShowFlow</div>
       </div>
-      <nav class="w-full sm:w-auto flex flex-nowrap overflow-x-auto items-center gap-2 mt-2 sm:mt-0 sm:ml-auto">
+      <nav class="w-full sm:w-auto flex flex-nowrap overflow-x-auto overflow-y-visible items-center gap-2 mt-2 sm:mt-0 sm:ml-auto">
         <button id="navAdmin" class="tab hidden">Admin</button>
         <button id="navParticipant" class="tab">Participant</button>
         <button id="navEvents" class="tab">Events</button>


### PR DESCRIPTION
## Summary
- ensure admin Tools dropdown is visible by allowing vertical overflow in header nav

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b78bf47cc483309075087725171bb6