### PR TITLE
feat: refresh layout with dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,19 +6,21 @@
   <title>ShowFlow — Events, Randomizer & Signups (Single-File)</title>
   <meta name="description" content="All-in-one, single-file event manager for open mics, comedy shows, raffles, and random drawings. Admin + Participant dashboards, QR signups, files, messages, analytics." />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='128' height='128' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='1.5'%3E%3Cpath d='M4 4h16v16H4z'/%3E%3Cpath d='M7 7h10v3H7zM7 12h10v5H7z'/%3E%3C/svg%3E" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     html, body { height: 100%; }
-    :root { --accent: #2563eb; }
-    body { background:#f9fafb; color:#111827; }
-    .glass { backdrop-filter: blur(8px); background: rgba(255,255,255,0.6); }
-    .btn { display:inline-flex; align-items:center; justify-content:center; padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; font-weight:500; transition: box-shadow .2s, border-color .2s, background .2s, color .2s; background:#fff; color:var(--accent); cursor:pointer; }
-    .btn:hover { box-shadow:0 1px 2px rgba(37,99,235,.4); background:var(--accent); color:#fff; }
+    :root { --accent: #9333ea; }
+    body { background:#0f172a; color:#e2e8f0; font-family:'Poppins',sans-serif; }
+    .glass { backdrop-filter: blur(8px); background: rgba(30,41,59,0.6); }
+    .btn { display:inline-flex; align-items:center; justify-content:center; padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; font-weight:500; transition: box-shadow .2s, border-color .2s, background .2s, color .2s; background:transparent; color:var(--accent); cursor:pointer; }
+    .btn:hover { box-shadow:0 1px 2px rgba(147,51,234,.4); background:var(--accent); color:#fff; }
     .btn-primary { background:var(--accent); color:#fff; border-color:var(--accent); }
-    .btn-primary:hover { background:#1e40af; }
+    .btn-primary:hover { background:#7e22ce; }
     .btn-danger { background:#dc2626; color:#fff; border-color:#b91c1c; }
     .btn-danger:hover { background:#b91c1c; }
-    .card { border:1px solid var(--accent); border-radius:1rem; padding:1rem; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,.1); }
+    .card { border:1px solid var(--accent); border-radius:1rem; padding:1rem; background:#1e293b; box-shadow:0 1px 2px rgba(0,0,0,.2); }
+    .landing-hero { padding:4rem 2rem; border-radius:1.5rem; background:linear-gradient(135deg,rgba(147,51,234,0.3),rgba(59,130,246,0.3)); }
     .grid-2 { display:grid; grid-template-columns:1fr; gap:1rem; }
     .grid-3 { display:grid; grid-template-columns:1fr; gap:1rem; }
     @media (min-width:640px) {
@@ -29,27 +31,27 @@
     @media (min-width:1024px) {
       .grid-3 { grid-template-columns:repeat(3,minmax(0,1fr)); }
     }
-    .pill { border:1px solid var(--accent); border-radius:9999px; padding:.125rem .5rem; font-size:.75rem; font-weight:600; color:var(--accent); background:#fff; }
-    .tab { padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; background:#fff; color:var(--accent); cursor:pointer; transition: background .2s, color .2s; }
+    .pill { border:1px solid var(--accent); border-radius:9999px; padding:.125rem .5rem; font-size:.75rem; font-weight:600; color:var(--accent); background:#1e293b; }
+    .tab { padding:.5rem .75rem; border:1px solid var(--accent); border-radius:.75rem; background:#1e293b; color:var(--accent); cursor:pointer; transition: background .2s, color .2s; }
     .tab:hover { background:var(--accent); color:#fff; }
     .tab-active { background:var(--accent); color:#fff; border-color:var(--accent); }
-    .input { width:100%; border:1px solid var(--accent); border-radius:.75rem; padding:.5rem .75rem; outline:none; background:#fff; color:#111827; }
-    .input:focus { box-shadow:0 0 0 2px rgba(37,99,235,0.3); border-color:var(--accent); }
+    .input { width:100%; border:1px solid var(--accent); border-radius:.75rem; padding:.5rem .75rem; outline:none; background:#0f172a; color:#e2e8f0; }
+    .input:focus { box-shadow:0 0 0 2px rgba(147,51,234,0.5); border-color:var(--accent); }
     .label { font-size:.75rem; font-weight:700; color:var(--accent); }
-    .table { width:100%; font-size:.875rem; border-collapse:collapse; color:#111827; }
+    .table { width:100%; font-size:.875rem; border-collapse:collapse; color:#e2e8f0; }
     .table th { text-align:left; color:var(--accent); font-weight:600; border-bottom:1px solid var(--accent); padding:.5rem .25rem; }
-    .table td { border-bottom:1px solid #ddd; padding:.5rem .25rem; }
-    .kbd { display:inline-block; border:1px solid var(--accent); border-radius:.375rem; padding:0 .25rem; font-size:.75rem; background:#f3f4f6; color:#111827; }
+    .table td { border-bottom:1px solid #334155; padding:.5rem .25rem; }
+    .kbd { display:inline-block; border:1px solid var(--accent); border-radius:.375rem; padding:0 .25rem; font-size:.75rem; background:#1e293b; color:#e2e8f0; }
     .divider { height:1px; background:var(--accent); margin:1rem 0; }
     .hidden { display:none !important; }
   </style>
 </head>
-  <body class="min-h-full bg-gray-50 text-gray-900">
+  <body class="min-h-full">
   <!-- Header -->
-  <header class="sticky top-0 z-40 bg-white/90 backdrop-blur border-b border-blue-600">
+  <header class="sticky top-0 z-40 backdrop-blur">
     <div class="max-w-7xl mx-auto px-4 py-3 flex flex-col sm:flex-row items-start sm:items-center gap-3">
       <div class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-lg bg-blue-600 text-white grid place-items-center font-bold">SF</div>
+        <div class="w-8 h-8 rounded-lg bg-purple-600 text-white grid place-items-center font-bold">SF</div>
         <div class="font-semibold">ShowFlow</div>
       </div>
         <nav class="w-full sm:w-auto flex flex-nowrap overflow-x-auto overflow-y-visible items-center gap-2 mt-2 sm:mt-0 sm:ml-auto">
@@ -66,7 +68,7 @@
             <button id="navRewards" class="tab hidden" data-tab="tab-rewards">Rewards</button>
             <button id="navForms" class="tab hidden" data-tab="tab-forms">Form Generator</button>
             <button id="navVouchers" class="tab hidden" data-tab="tab-vouchers">Vouchers</button>
-            <div class="border-l border-blue-600 h-6"></div>
+            <div class="border-l border-purple-600 h-6"></div>
             <button id="navExport" class="tab" title="Export all data">Export</button>
             <label class="tab cursor-pointer" title="Import a previously exported JSON">
               <input id="importInput" type="file" accept="application/json" class="hidden" />
@@ -79,13 +81,13 @@
 
   <main class="max-w-7xl mx-auto p-4 space-y-6">
     <!-- System banners -->
-      <div id="banner" class="hidden p-3 rounded-xl border border-blue-600 bg-white text-blue-600"></div>
+      <div id="banner" class="hidden p-3 rounded-xl border border-purple-600 bg-slate-800 text-purple-300"></div>
     <!-- Landing -->
-    <section id="viewLanding" class="card text-center space-y-4">
-      <h2 class="text-xl font-bold">Welcome to ShowFlow</h2>
-      <p class="text-sm text-gray-600">Are you an admin or a participant?</p>
+    <section id="viewLanding" class="landing-hero text-center space-y-8">
+      <h2 class="text-3xl font-bold">Welcome to ShowFlow</h2>
+      <p class="text-lg opacity-90">Run events with style. Are you an admin or a participant?</p>
       <div class="flex justify-center gap-4">
-        <button id="btnLandingAdmin" class="btn">Admin</button>
+        <button id="btnLandingAdmin" class="btn btn-primary">Admin</button>
         <button id="btnLandingParticipant" class="btn">Participant</button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restyle app with a purple-accented dark theme and Poppins font
- redesign landing page into gradient hero section
- align header and banners with updated color palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b829c73124833096253e8a4912c302